### PR TITLE
Add reusable form components and types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.11.0](https://github.com/NikDoe/livo/compare/v1.10.0...v1.11.0) (2024-09-12)
+
+
+### Features
+
+* add account subpages and components ([6e981f9](https://github.com/NikDoe/livo/commit/6e981f9f42bd332adef12a80ff6de5e93932eab7))
+
 # [1.10.0](https://github.com/NikDoe/livo/compare/v1.9.0...v1.10.0) (2024-09-11)
 
 

--- a/components/form/FormContainer.tsx
+++ b/components/form/FormContainer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useFormState } from 'react-dom';
+import { useEffect } from 'react';
+import { actionFunction } from '@/utils/types';
+import { useToast } from '@/hooks/use-toast';
+
+const initialState = {
+	message: '',
+};
+
+function FormContainer({
+	action,
+	children,
+}: {
+	action: actionFunction;
+	children: React.ReactNode;
+}) {
+	const [state, formAction] = useFormState(action, initialState);
+	const { toast } = useToast();
+
+	useEffect(() => {
+		if (state.message) {
+			toast({ description: state.message });
+		}
+	}, [state]);
+
+	return <form action={formAction}>{children}</form>;
+}
+
+export default FormContainer;

--- a/components/form/FormInput.tsx
+++ b/components/form/FormInput.tsx
@@ -1,0 +1,33 @@
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+
+
+type FormInputProps = {
+	name: string;
+	type: string;
+	label?: string;
+	defaultValue?: string;
+	placeholder?: string;
+};
+
+function FormInput(props: FormInputProps) {
+	const { name, type, defaultValue, label, placeholder } = props;
+
+	return (
+		<div className='mb-2'>
+			<Label htmlFor={name} className='capitalize'>
+				{label || name}
+			</Label>
+			<Input
+				id={name}
+				name={name}
+				type={type}
+				defaultValue={defaultValue}
+				placeholder={placeholder}
+				required
+			/>
+		</div>
+	);
+}
+
+export default FormInput;

--- a/components/form/SubmitButton.tsx
+++ b/components/form/SubmitButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { RxReload } from 'react-icons/rx';
+import { useFormStatus } from 'react-dom';
+import { Button } from '@/components/ui/button';
+
+type SubmitButtonProps = {
+	className?: string;
+	text?: string;
+};
+
+export function SubmitButton(props: SubmitButtonProps) {
+	const { className = '', text = 'отправить' } = props;
+	const { pending } = useFormStatus();
+
+	return (
+		<Button
+			type='submit'
+			disabled={pending}
+			className={`capitalize ${className}`}
+			size='lg'
+		>
+			{pending ? (
+				<>
+					<RxReload className='mr-2 h-4 w-4 animate-spin' />
+					Пожалуйста подождите...
+				</>
+			) : (
+				text
+			)}
+		</Button>
+	);
+}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@radix-ui/react-accordion": "^1.2.0",
 				"@radix-ui/react-checkbox": "^1.1.1",
 				"@radix-ui/react-dropdown-menu": "^2.1.1",
+				"@radix-ui/react-label": "^2.1.0",
 				"@radix-ui/react-select": "^2.1.1",
 				"@radix-ui/react-separator": "^1.1.0",
 				"@radix-ui/react-slot": "^1.1.0",
@@ -1260,6 +1261,29 @@
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-label": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+			"integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.0.0"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@radix-ui/react-accordion": "^1.2.0",
 		"@radix-ui/react-checkbox": "^1.1.1",
 		"@radix-ui/react-dropdown-menu": "^2.1.1",
+		"@radix-ui/react-label": "^2.1.0",
 		"@radix-ui/react-select": "^2.1.1",
 		"@radix-ui/react-separator": "^1.1.0",
 		"@radix-ui/react-slot": "^1.1.0",

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,0 +1,8 @@
+type ActionResponse = {
+    message: string;
+}
+
+export type actionFunction = (
+    prevState: any,
+    formData: FormData
+) => Promise<ActionResponse>;


### PR DESCRIPTION
## Description
This PR introduces reusable components and types for form management:

- **Reusable Components:**
  - `Input`: Custom input field component.
  - `Button`: Consistent button styling component.
  - `ContainerForm`: Wrapper component for form elements.

- **Custom Input:**
  - Utilized `label` from `shadcn/ui` to enhance custom input fields.

- **Types:**
  - Added `types.ts` in `utils` with a type definition for `actionFunction`, used for form actions.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation as necessary
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [ ] Any dependent changes have been merged and published in downstream modules

## Related Issues
No related issues.

## Additional Information
None.