### PR TITLE
Add favorite functionality and make button reusable for different object types

### DIFF
--- a/app/stays/[stayId]/page.tsx
+++ b/app/stays/[stayId]/page.tsx
@@ -9,7 +9,7 @@ type SingleStayPageProps = {
 function SingleStayPage({ params }: SingleStayPageProps) {
 	return (
 		<div>
-			<FavoriteToggleButton id={params.stayId} />
+			<FavoriteToggleButton id={params.stayId} favoriteType='stay' />
 			<p> Жильё № {params.stayId}</p>
 		</div >
 	);

--- a/components/mainPages/common/FavoriteSubmitButton.tsx
+++ b/components/mainPages/common/FavoriteSubmitButton.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components/ui/button';
+import { useFormStatus } from 'react-dom';
+import { FaHeart, FaRegHeart } from 'react-icons/fa';
+import { RxReload } from 'react-icons/rx';
+
+type FavoriteSubmitButtonProps = {
+	isFavorite: boolean;
+}
+
+function FavoriteSubmitButton({ isFavorite }: FavoriteSubmitButtonProps) {
+	const { pending } = useFormStatus();
+	return (
+		<Button
+			type='submit'
+			size='icon'
+			variant='outline'
+			className='p-2 cursor-pointer rounded-full border-2'
+		>
+			{pending ? (
+				<RxReload className=' animate-spin' />
+			) : isFavorite ? (
+				<FaHeart />
+			) : (
+				<FaRegHeart />
+			)}
+		</Button>
+	);
+}
+
+export default FavoriteSubmitButton;

--- a/components/mainPages/common/FavoriteToggleButton.tsx
+++ b/components/mainPages/common/FavoriteToggleButton.tsx
@@ -1,21 +1,26 @@
-import { FaHeart } from 'react-icons/fa';
-import { Button } from '@/components/ui/button';
 import { auth } from '@clerk/nextjs/server';
 import FavoriteSignInButton from './FavoriteSignInButton';
+import FavoriteToggleForm from './FavoriteToggleForm';
+import { FavoriteType, fetchFavoriteId } from '@/utils/actions';
 
 type FavoriteToggleButtonProps = {
+	favoriteType: FavoriteType;
 	id: string;
 }
 
-function FavoriteToggleButton({ id }: FavoriteToggleButtonProps) {
+async function FavoriteToggleButton({ favoriteType, id }: FavoriteToggleButtonProps) {
 	const { userId } = auth();
 
 	if (!userId) return <FavoriteSignInButton />;
 
+	const favoriteId = await fetchFavoriteId({ favoriteType, id });
+
 	return (
-		<Button size='icon' variant='ghost' className='p-2 cursor-pointer rounded-full border-2'>
-			<FaHeart className='w-4 h-4' />
-		</Button>
+		<FavoriteToggleForm
+			favoriteId={favoriteId}
+			favoriteType={favoriteType}
+			id={id}
+		/>
 	);
 }
 

--- a/components/mainPages/common/FavoriteToggleForm.tsx
+++ b/components/mainPages/common/FavoriteToggleForm.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { FormContainer } from '@/components/form';
+import { FavoriteType, toggleFavoriteAction } from '@/utils/actions';
+import { usePathname } from 'next/navigation';
+import FavoriteSubmitButton from './FavoriteSubmitButton';
+
+type FavoriteToggleFormProps = {
+	favoriteId: string | null;
+	favoriteType: FavoriteType;
+	id: string;
+}
+
+function FavoriteToggleForm(props: FavoriteToggleFormProps) {
+	const { favoriteId, favoriteType, id } = props;
+	const pathname = usePathname();
+	const toggleAction = toggleFavoriteAction.bind(null, {
+		favoriteId,
+		favoriteType,
+		pathname,
+		id,
+	});
+
+	return (
+		<FormContainer action={toggleAction}>
+			<FavoriteSubmitButton isFavorite={Boolean(favoriteId)} />
+		</FormContainer>
+	);
+}
+
+export default FavoriteToggleForm;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,18 +15,19 @@ datasource db {
 }
 
 model Profile {
-  id           String   @id @default(uuid())
-  clerkId      String   @unique
+  id           String     @id @default(uuid())
+  clerkId      String     @unique
   displayName  String
   realName     String
   profileImage String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
   stays        Stay[]
+  Favorite     Favorite[]
 }
 
 model Stay {
-  id          String   @id @default(uuid())
+  id          String     @id @default(uuid())
   stayTitle   String
   category    String
   image       String
@@ -38,8 +39,21 @@ model Stay {
   beds        Int
   baths       Int
   amenities   String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  profile     Profile  @relation(fields: [profileId], references: [clerkId], onDelete: Cascade)
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  profile     Profile    @relation(fields: [profileId], references: [clerkId], onDelete: Cascade)
   profileId   String
+  Favorite    Favorite[]
+}
+
+model Favorite {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  profile   Profile @relation(fields: [profileId], references: [clerkId], onDelete: Cascade)
+  profileId String
+
+  stay   Stay   @relation(fields: [stayId], references: [id], onDelete: Cascade)
+  stayId String
 }

--- a/utils/actions/favoriteActions.ts
+++ b/utils/actions/favoriteActions.ts
@@ -1,0 +1,81 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import db from '../db';
+import { getAuthUser, renderError } from './actionHelpers';
+
+export type FavoriteType = 'stay';
+
+const mappedFields = {
+	stay: 'stayId',
+} as const;
+
+interface FetchFavoriteIdParams {
+	favoriteType: FavoriteType;
+	id: string;
+}
+
+export const fetchFavoriteId = async ({
+	favoriteType,
+	id,
+}: FetchFavoriteIdParams) => {
+	const user = await getAuthUser();
+
+	const favoriteField = mappedFields[favoriteType];
+
+	const favorite = await db.favorite.findFirst({
+		where: {
+			[favoriteField]: id,
+			profileId: user.id,
+		},
+		select: {
+			id: true,
+		},
+	});
+
+	return favorite?.id || null;
+};
+
+interface ToggleFavoriteActionParams {
+	id: string;
+	favoriteId: string | null;
+	favoriteType: FavoriteType;
+	pathname: string;
+}
+
+export const toggleFavoriteAction = async (prevState: ToggleFavoriteActionParams) => {
+	const user = await getAuthUser();
+	const { id, favoriteId, favoriteType, pathname } = prevState;
+
+	const favoriteField = mappedFields[favoriteType];
+
+	try {
+		if (favoriteId) {
+			await db.favorite.delete({
+				where: {
+					id: favoriteId,
+				},
+			});
+		} else {
+			await db.favorite.create({
+				data: {
+					[favoriteField]: id,
+					profileId: user.id,
+				},
+			});
+		}
+		revalidatePath(pathname);
+		return { message: getFavoriteMessage(favoriteType, !!favoriteId) };
+	} catch (error) {
+		return renderError(error);
+	}
+};
+
+const getFavoriteMessage = (favoriteType: FavoriteType, isRemoved: boolean) => {
+	const favoriteTypeTranslations: Record<FavoriteType, string> = {
+		stay: 'Жильё',
+	};
+
+	const itemType = favoriteTypeTranslations[favoriteType];
+	return isRemoved ? `${itemType} удалено из избранного` : `${itemType} добавлено в избранное`;
+};

--- a/utils/actions/index.ts
+++ b/utils/actions/index.ts
@@ -10,3 +10,9 @@ export {
 	createStayAction,
 	fetchStays,
 } from './stayActions';
+
+export {
+	type FavoriteType,
+	fetchFavoriteId,
+	toggleFavoriteAction
+} from './favoriteActions';


### PR DESCRIPTION
## Description

- Added the functionality to allow users to add items to their favorites.
- The "Add to Favorites" button was refactored into a reusable component that supports different object types (e.g., stays, cars, experiences).
- This update improves code reusability and enables consistent behavior across various pages.

## Type of Change

- [x] New feature

## Checklist

- [x] My code follows the project’s coding style
- [x] I have performed a self-review of my code
- [x] I have tested the new functionality to ensure it works as expected
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings

## Additional Information
This feature allows users to favorite items across different object types, such as stays, cars, and experiences, with a consistent and reusable button component.