### PR TITLE
Restrict Users from Submitting Duplicate Reviews or Reviewing Own Listings

### DIFF
--- a/app/stays/[stayId]/page.tsx
+++ b/app/stays/[stayId]/page.tsx
@@ -68,6 +68,7 @@ async function SingleStayPage({ params }: SingleStayPageProps) {
 		profile,
 		description,
 		amenities,
+
 	} = stay;
 	const details = { beds, bedrooms, baths, guests };
 	const profileData = {
@@ -124,6 +125,7 @@ async function SingleStayPage({ params }: SingleStayPageProps) {
 					<ReviewSection
 						createReviewAction={createStayReviewAction}
 						fetchReviews={fetchStayReviews}
+						clerkId={profile.clerkId}
 						id={id}
 						title={stayTitle}
 					/>

--- a/components/common/reviews/ReviewSection.tsx
+++ b/components/common/reviews/ReviewSection.tsx
@@ -3,20 +3,24 @@ import SubmitReview from './SubmitReview';
 import { Separator } from '@/components/ui/separator';
 import Reviews from './Reviews';
 import type { actionFunction, FetchReviews } from '@/utils/types';
+import { findExistingStayReviewByUser } from '@/utils/actions';
 
 type ReviewSectionProps = {
+	clerkId: string;
 	id: string;
 	title: string;
 	createReviewAction: actionFunction;
 	fetchReviews: (id: string) => Promise<FetchReviews[]>;
 }
 
-function ReviewSection(props: ReviewSectionProps) {
-	const { id, title, createReviewAction, fetchReviews } = props;
-
+async function ReviewSection(props: ReviewSectionProps) {
+	const { clerkId, id, title, createReviewAction, fetchReviews } = props;
 	const { userId } = auth();
+	const isNotOwner = clerkId !== userId;
+	const reviewDoesNotExist =
+		userId && isNotOwner && !(await findExistingStayReviewByUser(userId, id));
 
-	const isShowAddReview = userId;
+	const isShow = userId;
 
 	const addReviewForm = (
 		<>
@@ -32,7 +36,7 @@ function ReviewSection(props: ReviewSectionProps) {
 
 	return (
 		<>
-			{isShowAddReview ? addReviewForm : null}
+			{reviewDoesNotExist && addReviewForm}
 			<Reviews fetchReviews={fetchReviews} id={id} />
 		</>
 	);

--- a/utils/actions/index.ts
+++ b/utils/actions/index.ts
@@ -25,4 +25,5 @@ export {
 	fetchStayReviews,
 	fetchStayReviewsByUser,
 	fetchStayRating,
+	findExistingStayReviewByUser,
 } from './reviews/stayReviewAction';

--- a/utils/actions/reviews/stayReviewAction.ts
+++ b/utils/actions/reviews/stayReviewAction.ts
@@ -80,3 +80,15 @@ export async function fetchStayRating(stayId: string) {
 		count: result[0]?._count.rating ?? 0,
 	};
 }
+
+export const findExistingStayReviewByUser = async (
+	userId: string,
+	stayId: string
+) => {
+	return db.stayReview.findFirst({
+		where: {
+			profileId: userId,
+			stayId,
+		},
+	});
+};


### PR DESCRIPTION
### Description
This PR adds logic to **restrict users** from:
1. Submitting a review if they have already left one for the same property or hiking trip.
2. Leaving a review on their own property or hiking trip.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Logic enhancement (non-breaking change that improves functionality)

### Checklist
- [x] The restriction logic is tested and functions as expected
- [x] Code is properly documented and follows project standards
- [x] Appropriate messages are shown to users when they are restricted from submitting reviews

### Related Issues
N/A

### Additional Information
In future updates, we could add a way for users to edit their reviews or provide feedback on why they cannot submit another review.