### PR TITLE
Restrict Housing Booking to Authenticated Users

### DIFF
--- a/components/common/bookings/BookingCalendar.tsx
+++ b/components/common/bookings/BookingCalendar.tsx
@@ -28,7 +28,7 @@ function BookingCalendar() {
 		<Popover>
 			<PopoverTrigger asChild>
 				<div
-					className='flex flex-col gap-y-4 bg-gray-100 rounded-md p-4 cursor-pointer'
+					className='flex flex-col gap-y-4 bg-muted rounded-md p-4 cursor-pointer'
 				>
 					<DateInput text='заезд' date={range?.from} />
 					<Separator />

--- a/components/common/bookings/BookingForm.tsx
+++ b/components/common/bookings/BookingForm.tsx
@@ -44,7 +44,7 @@ type FormRowProps = {
 function FormRow(props: FormRowProps) {
 	const { isDiscountRow = false, isTotalRow = false, amount, label } = props;
 	const totalClassName = isTotalRow
-		? 'bg-gray-100 font-bold'
+		? 'bg-muted font-bold'
 		: '';
 	const formatedAmount = formatCurrency(amount);
 	const amountText = isDiscountRow ? `-${formatedAmount}` : formatedAmount;

--- a/components/common/bookings/ConfirmBooking.tsx
+++ b/components/common/bookings/ConfirmBooking.tsx
@@ -1,9 +1,44 @@
-function ConfirmBooking() {
-	return (
-		<div>
+'use client';
 
-		</div>
+import { SignInButton, useAuth } from '@clerk/nextjs';
+import { Button } from '@/components/ui/button';
+import { useStay } from '@/utils/store';
+import FormContainer from '@/components/form/FormContainer';
+import { createStayBookingAction } from '@/utils/actions';
+import { SubmitButton } from '@/components/form';
+import { usePathname } from 'next/navigation';
+
+function ConfirmBooking() {
+	const pathname = usePathname();
+	const { userId } = useAuth();
+	const { stayId, range } = useStay((state) => state);
+	const checkIn = range?.from as Date;
+	const checkOut = range?.to as Date;
+
+	if (!userId)
+		return (
+			<SignInButton
+				mode='modal'
+				forceRedirectUrl={pathname}
+			>
+				<Button type='button' className='w-full mt-8'>
+					Авторизуйтесь для бронирования
+				</Button>
+			</SignInButton>
+		);
+
+	const createBooking = createStayBookingAction.bind(null, {
+		stayId,
+		checkIn,
+		checkOut,
+	});
+
+	return (
+		<section>
+			<FormContainer action={createBooking}>
+				<SubmitButton text='Забронировать' className='w-full mt-8' />
+			</FormContainer>
+		</section>
 	);
 }
-
 export default ConfirmBooking;

--- a/utils/actions/bookings/stayBookingActions.ts
+++ b/utils/actions/bookings/stayBookingActions.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import db from '@/utils/db';
+import { getAuthUser, renderError } from '../actionHelpers';
+import { calculateTotals } from '@/utils/calculateTotals';
+import { redirect } from 'next/navigation';
+
+type CreateActionPrevState = {
+	stayId: string;
+	checkIn: Date;
+	checkOut: Date;
+}
+
+export const createStayBookingAction = async (prevState: CreateActionPrevState) => {
+	const user = await getAuthUser();
+
+	const { stayId, checkIn, checkOut } = prevState;
+	const property = await db.stay.findUnique({
+		where: { id: stayId },
+		select: { price: true },
+	});
+
+	if (!property) {
+		return { message: 'Жильё не найдено' };
+	}
+
+	const { orderTotal, totalNights } = calculateTotals({
+		checkIn,
+		checkOut,
+		price: property.price,
+	});
+
+	try {
+		const booking = await db.stayBooking.create({
+			data: {
+				checkIn,
+				checkOut,
+				orderTotal,
+				totalNights,
+				profileId: user.id,
+				stayId,
+			},
+		});
+	} catch (error) {
+		return renderError(error);
+	}
+
+	redirect('/bookings');
+};

--- a/utils/actions/index.ts
+++ b/utils/actions/index.ts
@@ -27,3 +27,7 @@ export {
 	fetchStayRating,
 	findExistingStayReviewByUser,
 } from './reviews/stayReviewAction';
+
+export {
+	createStayBookingAction,
+} from './bookings/stayBookingActions';


### PR DESCRIPTION
### Description
This PR adds functionality that **restricts housing booking** to authenticated users. If a non-logged-in user attempts to book housing, they will be prompted to sign in or create an account first.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Authentication (requires login for booking functionality)

### Checklist
- [x] Booking functionality works correctly for authenticated users
- [x] Non-authenticated users are prompted to log in before booking
- [x] Code is properly documented and follows project standards

### Related Issues
N/A

### Additional Information
Future improvements may include showing a custom modal or redirecting users to a specific login page to enhance user experience.